### PR TITLE
Added lots of generic options which can be optionally set

### DIFF
--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -9,6 +9,14 @@ function compile({ template, values, manifests, stack, packDir }) {
 
   const secrets = [];
 
+  // Extra filters
+  env.addFilter('dumpyml', function(o, indent, opts) {
+    return yaml
+      .safeDump(o, opts)
+      .replace(/^/gm, ' '.repeat(indent))
+      .trim();
+  });
+
   function generateSecretName(name, value) {
     // Max length 64 chars - remove whitespace
     const secretName = name.replace(/ /g, '_').substr(0, 31);
@@ -52,7 +60,7 @@ function compile({ template, values, manifests, stack, packDir }) {
     parsed = yaml.safeLoad(interpolatedTpl);
   } catch (error) {
     console.log('Error parsing compiled docker-compose.yml');
-    console.log(error.reason);
+    console.log(error);
     console.log(interpolatedTpl);
     process.exit(1);
   }

--- a/src/pack/create.js
+++ b/src/pack/create.js
@@ -64,16 +64,14 @@ services:
 
 <<%- if default_port %>>
     #Ports
-{% for port in ports %}
-{% if loop.first %}
-    ports:
-{% endif %}
-      - {{ port }}
-{% endfor %}
+  {%- if ports | length %}
+    ports: {{ ports | dumpyml(4)}}
+  {%- endif %}
 <<% endif %>>
 
     # Deploy
     deploy:
+      {{ deploy | dumpyml(6)}}
       labels:
 <<%- if use_sync %>>
         - "swarm-sync.managed={{ swarm_sync.managed }}"
@@ -84,16 +82,6 @@ services:
         - "traefik.frontend.rule=Host:{{ traefik.hostname }}"
         - "traefik.backend.loadbalancer.stickiness={{ traefik.stickiness }}"
 <<%- endif %>>
-
-      # Add various extra "deploy" sections if they are defined
-{% for section in 
-  ["endpoint_mode", "mode", "placement", "replicas", "resources", "restart_policy", "rollback_config", "update_config"]
-%}
-    {%- if deploy[section] %}
-      {{section}}: {{ deploy[section] | dump }}
-    {%- endif %}
-{% endfor %}
-
     # /Deploy
 
     {%- if logging | length %}

--- a/src/pack/create.js
+++ b/src/pack/create.js
@@ -9,7 +9,7 @@ const composeFileName = 'docker-compose.tpl.yml';
 const packTemplate = `---
 pack:
   name: <<pack_name>>
-  version: 0.0.1
+  version: 0.1.0
   #home: URL for Pack homepage, e.g. github URL
   description: <<pack_description>>
   keywords: []
@@ -24,21 +24,28 @@ image:
   tag: <<image_tag>>
 <<%- if use_sync %>>
   tag_pattern: <<tag_pattern>>
-<<% endif %>>
+<<%- endif %>>
 
 <<%- if default_port %>>
   ports:
     - <<default_port>>
 <<%- endif %>>
 
+# Deploy allows all docker-compose options, except for labels
 deploy:
   mode: replicated
   replicas: 1
-  placement_constraints: []
-<<%- if use_sync %>>
-swarm-sync:
+
+<<% if use_sync %>>
+swarm_sync:
   managed: true
-<<% endif %>>
+<<%- endif %>>
+
+# Accepts same options/format as docker-compose
+logging:
+
+networks:
+  default: 
 
 <<%- if use_traefik %>>
 traefik:
@@ -53,7 +60,7 @@ version: '3.6'
 
 services:
   {{ service_name }}:
-    image: {{ image.repository }}:{{ image.tag }}
+    image: "{{ image.repository }}:{{ image.tag }}"
 
 <<%- if default_port %>>
     #Ports
@@ -65,35 +72,44 @@ services:
 {% endfor %}
 <<% endif %>>
 
+    # Deploy
     deploy:
-      mode: {{ deploy.mode }}
-      replicas: {{ deploy.replicas }}
-
-      # Placement constraints
-{% if deploy.placement_constraints | length %}
-      placement:
-        constraints:
-{% for p in deploy.placement_constraints %}
-          - "{{ p }}"
-{% endfor %}
-{% endif %}
-
       labels:
-        - "swarm-pack.managed=true"
 <<%- if use_sync %>>
-{% if swarm-sync.managed %}
-        - "swarm-sync.managed=true"
-{% endif %}
-{% if image.tag_pattern %}
-        - "swarm-sync.image-pattern={{ image.tag_pattern }}"
-{% endif %}
-<<% endif %>>
+        - "swarm-sync.managed={{ swarm_sync.managed }}"
+        {% if image.tag_pattern %}- "swarm-sync.image-pattern={{ image.tag_pattern }}"{% endif %}
+<<%- endif %>>
 <<%- if use_traefik %>>
         - "traefik.port=traefik.port"
         - "traefik.frontend.rule=Host:{{ traefik.hostname }}"
         - "traefik.backend.loadbalancer.stickiness={{ traefik.stickiness }}"
-<<% endif %>>
+<<%- endif %>>
 
+      # Add various extra "deploy" sections if they are defined
+{% for section in 
+  ["endpoint_mode", "mode", "placement", "replicas", "resources", "restart_policy", "rollback_config", "update_config"]
+%}
+    {%- if deploy[section] %}
+      {{section}}: {{ deploy[section] | dump }}
+    {%- endif %}
+{% endfor %}
+
+    # /Deploy
+
+    {%- if logging | length %}
+      {{logging}}: {{ logging | dump }}
+    {%- endif %}
+
+    networks:
+    {%- for net, def in networks %}
+      - {{ net }}
+    {%- endfor %}
+
+    # volumes:
+
+## Other assets (not-service)
+networks: {{ networks | dump }}
+# volumes:
 `;
 
 function generatePack(answers) {


### PR DESCRIPTION
Dramatically improves https://github.com/swarm-pack/swarm-pack/issues/6

When creating a template with `swarm-pack create` you will get fairly succinct templating to allow for arbitrary options in `deploy` section and a few others. This will basically dump whatever you put in `deploy` value into the docker-compose unchanged.