### PR TITLE
New helper: dumpblock_if_set

### DIFF
--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -9,10 +9,18 @@ function compile({ template, values, manifests, stack, packDir }) {
 
   const secrets = [];
 
-  // Extra filters
+  // Filters & helpers
   env.addFilter('dumpyml', function(o, indent, opts) {
     return yaml
       .safeDump(o, opts)
+      .replace(/^/gm, ' '.repeat(indent))
+      .trim();
+  });
+
+  env.addGlobal('dumpblock_if_set', ({ value, indent = 0, root = false }) => {
+    if (utils.isEmpty(value)) return '';
+    return yaml
+      .safeDump(root ? { [root]: value } : value)
       .replace(/^/gm, ' '.repeat(indent))
       .trim();
   });

--- a/src/pack/create.js
+++ b/src/pack/create.js
@@ -63,10 +63,8 @@ services:
     image: "{{ image.repository }}:{{ image.tag }}"
 
 <<%- if default_port %>>
-    #Ports
-  {%- if ports | length %}
-    ports: {{ ports | dumpyml(4)}}
-  {%- endif %}
+    # Ports
+    {{ dumpblock_if_set({value: ports, indent: 4, root: 'ports'}) }}
 <<% endif %>>
 
     # Deploy
@@ -84,9 +82,8 @@ services:
 <<%- endif %>>
     # /Deploy
 
-    {%- if logging | length %}
-      {{logging}}: {{ logging | dump }}
-    {%- endif %}
+    # Logging
+    {{ dumpblock_if_set({value: logging, indent: 4, root: 'logging'}) }}
 
     networks:
     {%- for net, def in networks %}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -92,11 +92,28 @@ function pipeableSpawn(stream, command, args, onExit, onError, onStdout, onStder
   });
 }
 
+/**
+ * Empty things:
+ *  - Zero length string
+ *  - Objects or arrays with no own properties / items
+ *  - Undefined, null, NaN
+ * Non-empty things:
+ *  - Strings with characters
+ *  - Objects and arrays with props or items
+ *  - All numbers including 0
+ */
+function isEmpty(thing) {
+  if (typeof thing === 'number' && !Number.isNaN(thing)) return false;
+  if (typeof thing === 'object' && thing !== null) return Object.keys(thing).length === 0;
+  return !thing;
+}
+
 module.exports = {
   getObjectProperty,
   readFile,
   ensurePathExisted,
   pipeableSpawn,
   isFileEmpty,
-  setObjectProperty
+  setObjectProperty,
+  isEmpty
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -98,13 +98,15 @@ function pipeableSpawn(stream, command, args, onExit, onError, onStdout, onStder
  *  - Objects or arrays with no own properties / items
  *  - Undefined, null, NaN
  * Non-empty things:
+ *  - Boolean true or false
+ *  - All numbers including 0
  *  - Strings with characters
  *  - Objects and arrays with props or items
- *  - All numbers including 0
  */
 function isEmpty(thing) {
   if (typeof thing === 'number' && !Number.isNaN(thing)) return false;
   if (typeof thing === 'object' && thing !== null) return Object.keys(thing).length === 0;
+  if (typeof thing === 'boolean') return false;
   return !thing;
 }
 


### PR DESCRIPTION
`dumpblock_if_set` nunjucks helper. Example:

```
{{ dumpblock_if_set({value: environment, indent: 4, root: 'environment'}) }}
```

Will dump value of `environment` as block style yaml if it is set and not empty. Optionally it takes a starting indent amount in spaces and a root key.