### PR TITLE
bugfix/deploy_label_config_fix: we should not force users to give dep…

### DIFF
--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -97,9 +97,10 @@ function compile({ template, values, manifests, stack, packDir }) {
       `com.docker.stack.namespace=${stack}`
     ];
 
+    const configLabels = config.deploy && config.deploy.labels || [];
     parsed.services[service] = _.merge(config, {
       deploy: {
-        labels: _.concat(config.deploy.labels, labelsStr)
+        labels: _.concat(configLabels, labelsStr)
       },
       labels
     });


### PR DESCRIPTION
…loyment config with labels, with out it there were YML generation errors.